### PR TITLE
Breaking: Include `Usage` type only, instead of excluding types

### DIFF
--- a/hic_aws_costing_tools/aws_costs.py
+++ b/hic_aws_costing_tools/aws_costs.py
@@ -6,17 +6,19 @@ import boto3
 
 DEFAULT_COST_TYPE = "UnblendedCost"
 DEFAULT_GRANULARITY = "MONTHLY"
+# Previously we excluded these types by default. Now we just include Usage instead.
 DEFAULT_EXCLUDE_RECORD_TYPES = [
-    "Credit",
-    "Refund",
-    "Tax",
-    # These two aren't documented on
-    # https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/manage-cost-categories.html#cost-categories-terms
-    # but were confirmed in AWS Support ticket 171570162800825
-    "Enterprise Discount Program Discount",
-    "Solution Provider Program Discount",
+    # "Credit",
+    # "Refund",
+    # "Tax",
+    # # These two aren't documented on
+    # # https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/manage-cost-categories.html#cost-categories-terms
+    # # but were confirmed in AWS Support ticket 171570162800825
+    # "Enterprise Discount Program Discount",
+    # "Solution Provider Program Discount",
 ]
-DEFAULT_INCLUDE_RECORD_TYPES = []
+# https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/manage-cost-categories.html#cost-categories-terms
+DEFAULT_INCLUDE_RECORD_TYPES = ["Usage"]
 EXPECTED_UNIT = "USD"
 
 

--- a/hic_aws_costing_tools/main.py
+++ b/hic_aws_costing_tools/main.py
@@ -4,6 +4,7 @@ from .aws_costs import (
     DEFAULT_COST_TYPE,
     DEFAULT_EXCLUDE_RECORD_TYPES,
     DEFAULT_GRANULARITY,
+    DEFAULT_INCLUDE_RECORD_TYPES,
     create_costs_message,
     create_costs_plain_output,
     get_time_period,
@@ -52,6 +53,12 @@ def main():
         help=f"Exclude these record types (default {DEFAULT_EXCLUDE_RECORD_TYPES})",
     )
     parser.add_argument(
+        "--include-types",
+        nargs="*",
+        default=DEFAULT_INCLUDE_RECORD_TYPES,
+        help=f"Include these record types (default {DEFAULT_INCLUDE_RECORD_TYPES})",
+    )
+    parser.add_argument(
         "--output",
         choices=["auto", "summary", "full", "csv", "flat"],
         default="auto",
@@ -71,6 +78,7 @@ def main():
             group1=args.group1,
             group2=args.group2,
             exclude_types=args.exclude_types,
+            include_types=args.include_types,
             output=args.output,
         )
     else:
@@ -84,6 +92,7 @@ def main():
             group1=args.group1,
             group2=args.group2,
             exclude_types=args.exclude_types,
+            include_types=args.include_types,
             output=args.output,
         )
         print(title)


### PR DESCRIPTION
Previously we excluded `Credit, Refund, Tax, Enterprise Discount Program Discount, Solution Provider Program Discount`.
Now we just include `Usage` only, which should be all we actually care about.